### PR TITLE
Task / Adding Time and Date to the dyno log

### DIFF
--- a/config/clock_autoposting_service.rb
+++ b/config/clock_autoposting_service.rb
@@ -1,4 +1,7 @@
 while true
+  puts "**************************************************************"
+  puts " Publish at: #{Time.now.getlocal('-08:00')} of #{Date.now} "
   system("ruby services/autoposting/tweet_posting.rb")
+  puts ".............................................................."
   sleep 28780
 end


### PR DESCRIPTION
### What does this PR?

*Adds in the heroku dyno the Date and Time that the tweet was tweeted.